### PR TITLE
Add hd and prompt parameters

### DIFF
--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -109,6 +109,12 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.approvalPrompt) {
     params['approval_prompt'] = options.approvalPrompt;
   }
+  if (options.prompt) {
+    params['prompt'] = options.prompt;
+  }
+  if (options.hd) {
+    params['hd'] = options.hd;
+  }
   return params;
 }
 


### PR DESCRIPTION
I have added the hd and prompt parameters.

The hd parameter allows the application to specify the "hosted domain" to authorize. This is usefull when you want to force the domain from your application to an specific google apps domain.

The promp parameter is like the approval_prompt, but it has three options `none`, `select_account`, and `consent`. prompt=consent does the same than approval_prompt=force but prompt=select_account forces thes account chooser even if the user is logged with a single account. It is also possible to use `prompt=select_account+consent`.
