### PR TITLE
This parameter allows providers who know the email address of the user to bypass the account chooser prompt screen

### DIFF
--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -109,6 +109,9 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.approvalPrompt) {
     params['approval_prompt'] = options.approvalPrompt;
   }
+  if (options.loginHint) {
+    params['login_hint'] = options.loginHint;
+  }
   return params;
 }
 


### PR DESCRIPTION
This is an essential parameter for efficient login flows for sites that don't want to rely on google to offer a choice of accounts to sign in with.

Added to OpenID Connect here, so should apply to the Microsoft OAuth 2 endpoint, too: https://bitbucket.org/openid/connect/commits/970a95b83add
