### PR TITLE
Support openid.realm parameter

### DIFF
--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -44,7 +44,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://accounts.google.com/o/oauth2/auth';
   options.tokenURL = options.tokenURL || 'https://accounts.google.com/o/oauth2/token';
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'google';
 }
@@ -72,20 +72,20 @@ util.inherits(Strategy, OAuth2Strategy);
 Strategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.get('https://www.googleapis.com/oauth2/v1/userinfo', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'google' };
       profile.id = json.id;
       profile.displayName = json.name;
       profile.name = { familyName: json.family_name,
                        givenName: json.given_name };
       profile.emails = [{ value: json.email }];
-      
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);
@@ -133,6 +133,11 @@ Strategy.prototype.authorizationParams = function(options) {
     // undocumented) is supported by Google's OAuth 2.0 endpoint was well.
     //   https://developers.google.com/accounts/docs/OAuth_ref
     params['hd'] = options.hostedDomain || options.hd;
+  }
+  if (options.openIdRealm) {
+    // This parameter is needed when migrating users from Google's OpenID 2.0 to OAuth 2.0
+    //   https://developers.google.com/accounts/docs/OpenID?hl=ja#adjust-uri
+    params['openid.realm'] = options.openIdRealm;
   }
   return params;
 }


### PR DESCRIPTION
Google has written migration guide for switching from OpenID 2.0 to OAuth 2.0. Everybody needs to migrate as Google's OpenID 2.0 support ends in 2015. Guide is available at https://developers.google.com/accounts/docs/OpenID. In step 1 on that guide, openid.real parameter is added to the initial authentication request.

This PR adds support for openid.realm option.



