### PR TITLE
Fixed OAuth Example 2

### DIFF
--- a/examples/oauth2/package.json
+++ b/examples/oauth2/package.json
@@ -2,7 +2,7 @@
   "name": "passport-google-oauth-examples-oauth2",
   "version": "1.0.0",
   "dependencies": {
-    "express": ">= 2.5.8",
+    "express": "2.5.8",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-google-oauth": ">= 0.0.0"

--- a/examples/oauth2/package.json
+++ b/examples/oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-google-oauth-examples-oauth2",
-  "version": "0.0.0",
+  "version": "2.5.8",
   "dependencies": {
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",

--- a/examples/oauth2/package.json
+++ b/examples/oauth2/package.json
@@ -1,8 +1,8 @@
 {
   "name": "passport-google-oauth-examples-oauth2",
-  "version": "2.5.8",
+  "version": "1.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": ">= 2.5.8",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-google-oauth": ">= 0.0.0"


### PR DESCRIPTION
Forced express to install version 2.5.8 to fix an issue in which `createServer` wasn't a known method (it's deprecated, and the current version of express does not support it).