### PR TITLE
Added gender to profile for oauth2

### DIFF
--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -82,6 +82,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile.name = { familyName: json.family_name,
                        givenName: json.given_name };
       profile.emails = [{ value: json.email }];
+      profile.gender = json.gender;      
       
       profile._raw = body;
       profile._json = json;


### PR DESCRIPTION
This is available from Google and is a part of the portable contact schema (http://portablecontacts.net/draft-spec.html#anchor16).  It would be great to have this!