### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-google-oauth",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "~0.1.4"
+    "passport-oauth": "^1.0.0"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
dependency on old passport-oauth brings old passport in and completely breaks code, relying on three arguments call to serializeUser, as req is lost by the old version of passport