### PR TITLE
allow display option

### DIFF
--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -134,6 +134,11 @@ Strategy.prototype.authorizationParams = function(options) {
     //   https://developers.google.com/accounts/docs/OAuth_ref
     params['hd'] = options.hostedDomain || options.hd;
   }
+  if (options.display) {
+    // Specify what kind of display consent screen to display to users.
+    //   https://developers.google.com/accounts/docs/OpenIDConnect#authenticationuriparameters
+    params['display'] = options.display;
+  }
   return params;
 }
 

--- a/test/oauth2-test.js
+++ b/test/oauth2-test.js
@@ -61,6 +61,10 @@ vows.describe('GoogleStrategy').addBatch({
       var params = strategy.authorizationParams({ hd: 'mycollege.edu' });
       assert.equal(params.hd, 'mycollege.edu');
     },
+    'should return display from display option': function (strategy) {
+      var params = strategy.authorizationParams({ display: 'touch' });
+      assert.equal(params.display, 'touch');
+    },
     'should return access_type and approval_prompt': function (strategy) {
       var params = strategy.authorizationParams({ accessType: 'offline', approvalPrompt: 'force' });
       assert.equal(params.access_type, 'offline');


### PR DESCRIPTION
I came across the need to support the `display: 'touch'` parameter:

https://developers.google.com/accounts/docs/OpenIDConnect#authenticationuriparameters