### PR TITLE
Update to Google+ API endpoint, add deprecation warnings

### DIFF
--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -5,7 +5,7 @@ var util = require('util')
   , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
   , InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
-var deprecatedScopes = {
+var DEPRECATED_SCOPES = {
   'https://www.googleapis.com/auth/userinfo.profile': 'profile',
   'https://www.googleapis.com/auth/userinfo.email': 'email',
 };
@@ -48,17 +48,19 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://accounts.google.com/o/oauth2/auth';
   options.tokenURL = options.tokenURL || 'https://accounts.google.com/o/oauth2/token';
-  options.scope = options.scope || ['profile'];
-
-  //warn deprecated scopes
-  options.scope.forEach(function (scope) {
-    var alternative = deprecatedScopes[scope];
-    if(!alternative) return;
-    console.warn(scope + ' is deprecated. Switch to ' + alternative);
-  });
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'google';
+  
+  //warn deprecated scopes
+  if (this._scope) {
+    var scopes = Array.isArray(this._scope) ? this._scope : [ this._scope ];
+    scopes.forEach(function(scope) {
+      var alt = DEPRECATED_SCOPES[scope];
+      if (!alt) return;
+      console.warn(scope + ' is deprecated. Switch to ' + alt);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Builds on #45, with changes:

- scope is not defaulted to "profile".  Rationale: providers are frequently changing their recommended best practices, and assuming defaults in the library leads to maintenance requirements on an third-party schedule.  This is not something I want to be responsible for, so applications need to pass in their own scopes (and be responsible for tracking changes)

- adjusted deprecation warnings to account for scope being passed as a string, rather than an array, which is allowed by the strategy