### PR TITLE
OAuth 2.0 Scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ passport.use(new GoogleStrategy({
 Use `passport.authenticate()`, specifying the `'google'` strategy, to
 authenticate requests.
 
+Authentication with Google requires an extra scope parameter.  For information, go [here](https://developers.google.com/accounts/docs/OpenIDConnect#scope-param).
+
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
@@ -89,13 +91,14 @@ passport.use(new GoogleStrategy({
 
 Use `passport.authenticate()`, specifying the `'google'` strategy, to
 authenticate requests.
+Authentication with Google requires an extra scope parameter.  For information, go [here](https://developers.google.com/accounts/docs/OpenIDConnect#scope-param).
 
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
 ```Javascript
 app.get('/auth/google',
-  passport.authenticate('google'));
+  passport.authenticate('google', { scope: 'https://www.googleapis.com/auth/plus.login' }));
 
 app.get('/auth/google/callback', 
   passport.authenticate('google', { failureRedirect: '/login' }),


### PR DESCRIPTION
OAuth 2.0 requires a scope parameter to work, just like OAuth 1.  I used a different URL in OAuth 2, as I seemed to have problems using https://www.google.com/m8/feeds.  It might be a local problem, but the url I suggested might be better suited for basic use-cases.

I also provided links to the Google documentation on scope.  It's not great, but it helps.