### PR TITLE
Making the oauth2 example to be compatible with Express 4.x

### DIFF
--- a/examples/oauth2/app.js
+++ b/examples/oauth2/app.js
@@ -1,4 +1,8 @@
 var express = require('express')
+  , cookieParser = require('cookie-parser')
+  , bodyParser = require('body-parser')
+  , expressSession = require('express-session')
+  , methodOverride = require('method-override')
   , passport = require('passport')
   , util = require('util')
   , GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
@@ -50,24 +54,20 @@ passport.use(new GoogleStrategy({
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
-app.configure(function() {
-  app.set('views', __dirname + '/views');
-  app.set('view engine', 'ejs');
-  app.use(express.logger());
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
-  // Initialize Passport!  Also use passport.session() middleware, to support
-  // persistent login sessions (recommended).
-  app.use(passport.initialize());
-  app.use(passport.session());
-  app.use(app.router);
-  app.use(express.static(__dirname + '/public'));
-});
+app.set('views', __dirname + '/views');
+app.set('view engine', 'ejs');
+app.use(cookieParser());
+app.use(bodyParser());
+app.use(expressSession({ secret: 'keyboard cat' }));
+app.use(methodOverride());
+// Initialize Passport!  Also use passport.session() middleware, to support
+// persistent login sessions (recommended).
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(express.static(__dirname + '/public'));
 
 
 app.get('/', function(req, res){

--- a/examples/oauth2/package.json
+++ b/examples/oauth2/package.json
@@ -5,6 +5,10 @@
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
-    "passport-google-oauth": ">= 0.0.0"
+    "passport-google-oauth": ">= 0.0.0",
+    "cookie-parser": "~1.3.5",
+    "body-parser": "~1.13.2",
+    "express-session": "~1.11.3",
+    "method-override": "~2.3.4"
   }
 }


### PR DESCRIPTION
Because the version is not specified in the package.json file, the example ended up becoming obsolete.
The oauth2 is now working.
I did not touch the oauth example.