### PR TITLE
Update OAuth2 URLs, remove requirement on Google Plus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: "node_js"
 node_js:
-  - 0.8
   - 0.10
   - 0.12

--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -46,8 +46,8 @@ var DEPRECATED_SCOPES = {
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://accounts.google.com/o/oauth2/auth';
-  options.tokenURL = options.tokenURL || 'https://accounts.google.com/o/oauth2/token';
+  options.authorizationURL = options.authorizationURL || 'https://accounts.google.com/o/oauth2/v2/auth';
+  options.tokenURL = options.tokenURL || 'https://www.googleapis.com/oauth2/v4/token';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'google';
@@ -84,7 +84,7 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get('https://www.googleapis.com/plus/v1/people/me', accessToken, function (err, body, res) {
+  this._oauth2.get('https://www.googleapis.com/oauth2/v3/userinfo', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
 
     try {


### PR DESCRIPTION
Updates the authorisation and token URLs, to use the latest versions, as per https://accounts.google.com/.well-known/openid-configuration.

Also uses the OAuth2 endpoint for user info, meaning it is no longer necessary to enable the Google+ API in the developers console.