### PR TITLE
Upgrade OAuth2 express to 4.x to make it functioning again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # Node.js
 node_modules/*
 npm-debug.log
+/**/node_modules/
+

--- a/examples/oauth2/package.json
+++ b/examples/oauth2/package.json
@@ -2,8 +2,11 @@
   "name": "passport-google-oauth-examples-oauth2",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "body-parser": "^1.14.2",
+    "cookie-parser": "^1.4.0",
     "ejs": ">= 0.0.0",
+    "express": ">= 4.0.0",
+    "morgan": "^1.6.1",
     "passport": ">= 0.0.0",
     "passport-google-oauth": ">= 0.0.0"
   }


### PR DESCRIPTION
I cloned this project and tried to execute the example with OAuth2 and it didn't work due to express 3.x code while npm downloaded express 4.x

These changes upgrades the code to express 4.x

The other solution is to set the express version to the constant 3.0.0