### PR TITLE
changes to allow custom strategy name

### DIFF
--- a/lib/passport-google-oauth/oauth.js
+++ b/lib/passport-google-oauth/oauth.js
@@ -48,7 +48,7 @@ function Strategy(options, verify) {
   options.sessionKey = options.sessionKey || 'oauth:google';
 
   OAuthStrategy.call(this, options, verify);
-  this.name = 'google';
+  this.name = (typeof options.name === 'string' && options.name.length > 0) ? options.name : 'google';
 }
 
 /**

--- a/lib/passport-google-oauth/oauth2.js
+++ b/lib/passport-google-oauth/oauth2.js
@@ -50,7 +50,7 @@ function Strategy(options, verify) {
   options.tokenURL = options.tokenURL || 'https://accounts.google.com/o/oauth2/token';
 
   OAuth2Strategy.call(this, options, verify);
-  this.name = 'google';
+  this.name = (typeof options.name === 'string' && options.name.length > 0) ? options.name : 'google';
   
   //warn deprecated scopes
   if (this._scope) {


### PR DESCRIPTION
I have a case where I need multiple custom google strategies to handle several different domains in one application. Allowing the developer to supply a custom name in the strategy, which is set in the options parameter, seems like a valid approach.