### PR TITLE
Update passport-google-oauth20 dependency to 2.x.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "main": "./lib",
   "dependencies": {
     "passport-google-oauth1": "1.x.x",
-    "passport-google-oauth20": "1.x.x"
+    "passport-google-oauth20": "2.x.x"
   },
   "devDependencies": {
     "make-node": "0.3.x",


### PR DESCRIPTION
This PR updates the passport-google-oauth20 dependency to 2.x.x, incorporating in the migration necessitated by the Google+ API shutdown (jaredhanson/passport-google-oauth2#53).